### PR TITLE
fix: plural naming for helpers

### DIFF
--- a/Source/Cogworks.Umbraco.Essentials/Cogworks.Umbraco.Essentials.csproj
+++ b/Source/Cogworks.Umbraco.Essentials/Cogworks.Umbraco.Essentials.csproj
@@ -279,8 +279,8 @@
     <Compile Include="Handlers\RobotsHandler.cs" />
     <Compile Include="Helpers\AppSettings.cs" />
     <Compile Include="Helpers\CookieHelper.cs" />
-    <Compile Include="Helpers\DomainHelpers.cs" />
-    <Compile Include="Helpers\ExpressionHelpers.cs" />
+    <Compile Include="Helpers\DomainHelper.cs" />
+    <Compile Include="Helpers\ExpressionHelper.cs" />
     <Compile Include="Infrastructure\ServerRegistrar.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\BaseEmailService.cs" />

--- a/Source/Cogworks.Umbraco.Essentials/Helpers/DomainHelper.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Helpers/DomainHelper.cs
@@ -12,7 +12,7 @@ using Umbraco.Web.Routing;
 
 namespace Cogworks.Umbraco.Essentials.Helpers
 {
-    public static class DomainHelpers
+    public static class DomainHelper
     {
         public static IPublishedContent GetRootNodeFromDomain(HttpContextBase context, IUmbracoContextFactory umbracoContextFactory = null)
         {

--- a/Source/Cogworks.Umbraco.Essentials/Helpers/ExpressionHelper.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Helpers/ExpressionHelper.cs
@@ -2,7 +2,7 @@
 
 namespace Cogworks.Umbraco.Essentials.Helpers
 {
-    public static class ExpressionHelpers
+    public static class ExpressionHelper
     {
         public static string GetNameFromMemberExpression(Expression expression)
             => expression switch


### PR DESCRIPTION
<!--
Thank you for your pull request, #h5yr! But it's just a beginning. 
Please provide details where it's required and review the requirements below.
-->
**What this PR does / why it's submitted / why we need it**:

Changed helpers name.

---

**Checklist**:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My PR has a descriptive title (not a vague title like `Needed this`)
- [x] Title and all the commits follow [commitlint guidelines](https://github.com/conventional-changelog/commitlint#what-is-commitlint)
- [x] My PR targets the `develop` branch or appropriate `release` branch
- [x] I've placed the link to the corresponding Trello card or issue which this PR fixes/address below ⤵️

---

Fixes: https://github.com/thecogworks/Cogworks.Umbraco.Essentials/issues/2