### PR TITLE
chore: fixing "Cannot create an instance of an interface" on image build

### DIFF
--- a/Source/Cogworks.Umbraco.Essentials/Builders/Interfaces/IResponsiveImageBuilder.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Builders/Interfaces/IResponsiveImageBuilder.cs
@@ -11,7 +11,7 @@ namespace Cogworks.Umbraco.Essentials.Builders.Interfaces
             IPublishedContent image,
             string cropPrefix,
             string altText = null,
-            IReadOnlyDictionary<string, string> breakpoints = null,
+            ImageBreakpoints breakpoints = null,
             string imageClass = null,
             string containerClass = null,
             string cropSeparator = StringConstants.Separators.Hyphen,
@@ -24,7 +24,7 @@ namespace Cogworks.Umbraco.Essentials.Builders.Interfaces
         IReadOnlyList<ImageSource> BuildResponsiveImageSources(
             IPublishedContent image,
             string cropPrefix,
-            IReadOnlyDictionary<string, string> breakpoints = null,
+            ImageBreakpoints breakpoints = null,
             string cropSeparator = StringConstants.Separators.Hyphen,
             int? width = null,
             int? height = null,

--- a/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
@@ -58,7 +58,7 @@ namespace Cogworks.Umbraco.Essentials.Builders
         {
             if (!breakpoints.HasAny())
             {
-                breakpoints = new ImageBreakpoints(BreakPointConstants.DefaultBreakpoints.ToList());
+                breakpoints = new ImageBreakpoints(BreakPointConstants.DefaultBreakpoints);
             }
 
             var imageSources = new List<ImageSource>();

--- a/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
@@ -16,7 +16,7 @@ namespace Cogworks.Umbraco.Essentials.Builders
         public ResponsiveImage Build(IPublishedContent image,
             string cropPrefix,
             string altText = null,
-            IReadOnlyDictionary<string, string> breakpoints = null,
+            ImageBreakpoints breakpoints = null,
             string imageClass = null,
             string containerClass = null,
             string cropSeparator = StringConstants.Separators.Hyphen,
@@ -46,7 +46,7 @@ namespace Cogworks.Umbraco.Essentials.Builders
 
         public IReadOnlyList<ImageSource> BuildResponsiveImageSources(IPublishedContent image,
             string cropPrefix,
-            IReadOnlyDictionary<string, string> breakpoints = null,
+            ImageBreakpoints breakpoints = null,
             string cropSeparator = StringConstants.Separators.Hyphen,
             int? width = null,
             int? height = null,
@@ -55,20 +55,26 @@ namespace Cogworks.Umbraco.Essentials.Builders
             int? quality = null,
             string fileExtension = null)
         {
-            breakpoints ??= BreakPointConstants.DefaultBreakpoints;
+            if (breakpoints.HasValue() && !breakpoints.BreakpointsValues.HasAny())
+            {
+                breakpoints = new ImageBreakpoints
+                {
+                    BreakpointsValues = BreakPointConstants.DefaultBreakpoints
+                };
+            }
 
             var imageSources = new List<ImageSource>();
 
-            foreach (var breakPoint in breakpoints)
+            foreach (var breakPoint in breakpoints.BreakpointsValues)
             {
                 var cropAlias = $"{cropPrefix}{cropSeparator}{breakPoint.Key}";
 
                 if (enableWebP)
                 {
-                    var imageSourceWithWebp = image.GetCropUrls(cropAlias, width, height, includeRetina, true, quality);
-                    if (imageSourceWithWebp.HasValue())
+                    var imageSourceWithWebP = image.GetCropUrls(cropAlias, width, height, includeRetina, true, quality);
+                    if (imageSourceWithWebP.HasValue())
                     {
-                        imageSources.Add(new ImageSource(imageSourceWithWebp, breakPoint.Value, $"image/{ImageCropConstants.WebP}"));
+                        imageSources.Add(new ImageSource(imageSourceWithWebP, breakPoint.Value, $"image/{ImageCropConstants.WebP}"));
                     }
                 }
 

--- a/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Cogworks.Essentials.Extensions;
 using Cogworks.Umbraco.Essentials.Builders.Interfaces;
 using Cogworks.Umbraco.Essentials.Constants;
@@ -55,17 +56,14 @@ namespace Cogworks.Umbraco.Essentials.Builders
             int? quality = null,
             string fileExtension = null)
         {
-            if (breakpoints.HasValue() && !breakpoints.BreakpointsValues.HasAny())
+            if (!breakpoints.HasAny())
             {
-                breakpoints = new ImageBreakpoints
-                {
-                    BreakpointsValues = BreakPointConstants.DefaultBreakpoints
-                };
+                breakpoints = new ImageBreakpoints(BreakPointConstants.DefaultBreakpoints.ToList());
             }
 
             var imageSources = new List<ImageSource>();
 
-            foreach (var breakPoint in breakpoints.BreakpointsValues)
+            foreach (var breakPoint in breakpoints)
             {
                 var cropAlias = $"{cropPrefix}{cropSeparator}{breakPoint.Key}";
 

--- a/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Builders/ResponsiveImageBuilder.cs
@@ -77,16 +77,18 @@ namespace Cogworks.Umbraco.Essentials.Builders
                         imageSources.Add(new ImageSource(imageSourceWithWebP, breakPoint.Value, $"image/{ImageCropConstants.WebP}"));
                     }
                 }
-
-                var imageSource = image.GetCropUrls(cropAlias, width, height, includeRetina);
-
-                if (imageSource.HasValue())
+                else
                 {
-                    var imageExtension = fileExtension.HasValue()
-                        ? fileExtension
-                        : Path.GetExtension(image.Url())?.TrimStart(StringConstants.Separators.Dot.ToChar());
+                    var imageSource = image.GetCropUrls(cropAlias, width, height, includeRetina);
 
-                    imageSources.Add(new ImageSource(imageSource, breakPoint.Value, $"image/{imageExtension}"));
+                    if (imageSource.HasValue())
+                    {
+                        var imageExtension = fileExtension.HasValue()
+                            ? fileExtension
+                            : Path.GetExtension(image.Url())?.TrimStart(StringConstants.Separators.Dot.ToChar());
+
+                        imageSources.Add(new ImageSource(imageSource, breakPoint.Value, $"image/{imageExtension}"));
+                    }
                 }
             }
 

--- a/Source/Cogworks.Umbraco.Essentials/Cogworks.Umbraco.Essentials.csproj
+++ b/Source/Cogworks.Umbraco.Essentials/Cogworks.Umbraco.Essentials.csproj
@@ -331,6 +331,7 @@
     <Compile Include="Helpers\DomainHelper.cs" />
     <Compile Include="Helpers\ExpressionHelper.cs" />
     <Compile Include="Infrastructure\ServerRegistrar.cs" />
+    <Compile Include="Models\ImageBreakpoints.cs" />
     <Compile Include="Models\ImageSource.cs" />
     <Compile Include="Models\ResponsiveImage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/Cogworks.Umbraco.Essentials/Controllers/Actions/ResponsiveImageSurfaceController.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Controllers/Actions/ResponsiveImageSurfaceController.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 using Cogworks.Essentials.Constants;
 using Cogworks.Essentials.Extensions;
 using Cogworks.Umbraco.Essentials.Builders.Interfaces;
+using Cogworks.Umbraco.Essentials.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web.Mvc;
 
@@ -17,7 +17,7 @@ namespace Cogworks.Umbraco.Essentials.Controllers.Actions
 
         [ChildActionOnly]
         public virtual ActionResult ResponsiveImage(IPublishedContent image, string cropPrefix, string altText = null,
-            IReadOnlyDictionary<string, string> breakpoints = null, string imageClass = null, string containerClass = null,
+            ImageBreakpoints breakpoints = null, string imageClass = null, string containerClass = null,
             string cropSeparator = StringConstants.Separators.Hyphen, int? width = null, int? height = null, bool includeRetina = true,
             bool enableWebP = false, int? quality = null)
         {

--- a/Source/Cogworks.Umbraco.Essentials/Models/ImageBreakpoints.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Models/ImageBreakpoints.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Cogworks.Umbraco.Essentials.Models
+{
+    public class ImageBreakpoints
+    {
+        public IReadOnlyDictionary<string, string> BreakpointsValues { get; set; }
+    }
+}

--- a/Source/Cogworks.Umbraco.Essentials/Models/ImageBreakpoints.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Models/ImageBreakpoints.cs
@@ -1,9 +1,44 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Cogworks.Umbraco.Essentials.Models
 {
-    public class ImageBreakpoints
+    public class ImageBreakpoints : IEnumerable<KeyValuePair<string, string>>
     {
-        public IReadOnlyDictionary<string, string> BreakpointsValues { get; set; }
+        private readonly IDictionary<string, string> _breakpoints;
+
+        public ImageBreakpoints() => _breakpoints = new Dictionary<string, string>();
+
+        public ImageBreakpoints(IEnumerable<KeyValuePair<string, string>> breakpoints)
+            => _breakpoints = breakpoints.ToDictionary(x => x.Key, x => x.Value)
+                              ?? throw new NullReferenceException($"Breakpoints {nameof(breakpoints)} are not assigned.");
+
+        public IEnumerable<string> CropAliases => _breakpoints.Keys;
+
+        public IEnumerable<string> CropValues => _breakpoints.Values;
+
+        public int Count => _breakpoints.Count;
+
+        public string this[string key]
+            => TryGetCropValue(key, out var value)
+                ? value
+                : default;
+
+        public bool ContainsCrop(string cropAlias)
+            => _breakpoints.ContainsKey(cropAlias);
+
+        public bool TryGetCropValue(string cropAlias, out string value)
+            => _breakpoints.TryGetValue(cropAlias, out value);
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => _breakpoints.GetEnumerator();
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+            => _breakpoints.GetEnumerator();
+
+        public IEnumerable<KeyValuePair<string, string>> GetBreakpoints()
+            => _breakpoints.ToArray();
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request, #h5yr! But it's just a beginning. 
Please provide details where it's required and review the requirements below.
-->
**What this PR does / why it's submitted / why we need it**:
When using the image builder this error was being thrown "MissingMethodException: Cannot create an instance of an interface" this was the best way around it.

Now if someone wants to change the default breakpoints the need to pass this new object with the breakpoint values.

A Dictionary type worked but it couldn't be used from the razor view, somehow the model binder was picking all the properties sent by the action in this dictionary.

---

**Checklist**:
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] My PR has a descriptive title (not a vague title like `Needed this`)
- [x] Title and all the commits follow [commitlint guidelines](https://github.com/conventional-changelog/commitlint#what-is-commitlint)
- [x] My PR targets the `develop` branch or appropriate `release` branch