### PR TITLE
fix: removing unnecessary json formatting 

### DIFF
--- a/Source/Cogworks.Umbraco.Essentials/Components/ApiConfigurationComponent.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Components/ApiConfigurationComponent.cs
@@ -1,25 +1,18 @@
 ﻿using System.Web.Http;
 using System.Web.Mvc;
 using System.Web.Routing;
-using Newtonsoft.Json;
 using Umbraco.Core.Composing;
 
 namespace Cogworks.Umbraco.Essentials.Components
 {
     public class ApiConfigurationComponent : IComponent
     {
-        private readonly JsonSerializerSettings _jsonSerializerSettings;
-
-        public ApiConfigurationComponent(JsonSerializerSettings jsonSerializerSettings)
-            => _jsonSerializerSettings = jsonSerializerSettings;
-
         public void Initialize()
         {
             RouteTable.Routes.MapMvcAttributeRoutes();
             GlobalConfiguration.Configuration.MapHttpAttributeRoutes();
 
             var jsonFormatter = GlobalConfiguration.Configuration.Formatters.JsonFormatter;
-            jsonFormatter.SerializerSettings = _jsonSerializerSettings;
             jsonFormatter.UseDataContractJsonSerializer = false;
         }
 

--- a/Source/Cogworks.Umbraco.Essentials/Composers/ApiConfigurationComposer.cs
+++ b/Source/Cogworks.Umbraco.Essentials/Composers/ApiConfigurationComposer.cs
@@ -1,33 +1,22 @@
 ﻿using System.Linq;
 using System.Web.Http.Controllers;
 using Cogworks.Umbraco.Essentials.Components;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 
 namespace Cogworks.Umbraco.Essentials.Composers
 {
 #pragma warning disable CA1812 // Class never use
+
     internal class ApiConfigurationComposer : IUserComposer
 #pragma warning restore CA1812 // Class never use
     {
         public void Compose(Composition composition)
         {
             RegisterApiControllers(composition);
-            RegisterJsonSettings(composition);
 
             composition.Components().Append<ApiConfigurationComponent>();
         }
-
-        private static void RegisterJsonSettings(IRegister composition)
-            => composition.Register(_ => new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                Formatting = Formatting.Indented,
-                NullValueHandling = NullValueHandling.Ignore
-            }, Lifetime.Singleton);
 
         private void RegisterApiControllers(IRegister container)
         {


### PR DESCRIPTION
This is changing the backoffice json formatting, if we need to change the json formatting we can use create an attribute for it https://our.umbraco.com/forum/using-umbraco-and-getting-started/105550-umbraco-8-webapi-return-camelcase#comment-329297